### PR TITLE
Add navigation and loading logic for generated UI

### DIFF
--- a/Assets/Scripts/UI/CompleteUIGenerator.cs
+++ b/Assets/Scripts/UI/CompleteUIGenerator.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using TMPro;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,6 +38,8 @@ public class CompleteUIGenerator : MonoBehaviour
     private EventSystem eventSystem;
     private Dictionary<string, GameObject> createdPanels = new Dictionary<string, GameObject>();
     private List<ConcreteUIPanel> allPanels = new List<ConcreteUIPanel>();
+    private Image loadingFillImage;
+    private Coroutine loadingCoroutine;
     
     void Start()
     {
@@ -380,11 +383,19 @@ public class CompleteUIGenerator : MonoBehaviour
         CreateTitle(panel.transform, "GAME TITLE", new Vector2(0, 200));
         
         // Buttons
-        Button newGameBtn = CreateButton(panel.transform, "NUEVO JUEGO", new Vector2(0, 50), new Vector2(300, 60), 
-            () => Debug.Log("Nueva partida"));
+        Button newGameBtn = CreateButton(panel.transform, "NUEVO JUEGO", new Vector2(0, 50), new Vector2(300, 60),
+            () => {
+                uiManager?.ShowPanel("Loading");
+                if (loadingCoroutine != null) StopCoroutine(loadingCoroutine);
+                loadingCoroutine = StartCoroutine(SimulateLoading());
+            });
         
-        CreateButton(panel.transform, "CARGAR JUEGO", new Vector2(0, -20), new Vector2(300, 60), 
-            () => Debug.Log("Cargar partida"));
+        CreateButton(panel.transform, "CARGAR JUEGO", new Vector2(0, -20), new Vector2(300, 60),
+            () => {
+                uiManager?.ShowPanel("Loading");
+                if (loadingCoroutine != null) StopCoroutine(loadingCoroutine);
+                loadingCoroutine = StartCoroutine(SimulateLoading());
+            });
         
         CreateButton(panel.transform, "OPCIONES", new Vector2(0, -90), new Vector2(300, 60), 
             () => uiManager?.ShowPanel("OptionsMain"));
@@ -491,7 +502,7 @@ public class CompleteUIGenerator : MonoBehaviour
         
         // Health bar (top left)
         CreateProgressBar(panel.transform, "Salud", new Vector2(-700, 400), new Vector2(200, 20), Color.red);
-        
+
         // Stamina bar (below health)
         CreateProgressBar(panel.transform, "Stamina", new Vector2(-700, 360), new Vector2(200, 20), Color.yellow);
         
@@ -541,7 +552,7 @@ public class CompleteUIGenerator : MonoBehaviour
         CreateTitle(panel.transform, "CARGANDO...", new Vector2(0, 50));
         
         // Loading bar
-        CreateProgressBar(panel.transform, "", new Vector2(0, -50), new Vector2(400, 30), primaryColor);
+        loadingFillImage = CreateProgressBar(panel.transform, "", new Vector2(0, -50), new Vector2(400, 30), primaryColor);
     }
     
     void CreateTitle(Transform parent, string text, Vector2 position)
@@ -569,7 +580,7 @@ public class CompleteUIGenerator : MonoBehaviour
         }
     }
     
-    void CreateProgressBar(Transform parent, string labelText, Vector2 position, Vector2 size, Color barColor)
+    Image CreateProgressBar(Transform parent, string labelText, Vector2 position, Vector2 size, Color barColor)
     {
         GameObject barGO = new GameObject($"ProgressBar_{labelText}");
         barGO.transform.SetParent(parent, false);
@@ -619,6 +630,8 @@ public class CompleteUIGenerator : MonoBehaviour
             labelComponent.fontSize = 16;
             labelComponent.alignment = TextAlignmentOptions.Center;
         }
+
+        return fillImage;
     }
     
     System.Collections.IEnumerator SelectButtonDelayed(Button button)
@@ -634,17 +647,20 @@ public class CompleteUIGenerator : MonoBehaviour
     void SetupNavigation()
     {
         LogDebug("🧭 Setting up panel navigation...");
-        
+
+        SetPanelNavigation("MainMenu", "OptionsMain", "");
         SetPanelNavigation("OptionsMain", "", "MainMenu");
         SetPanelNavigation("AudioOptions", "", "OptionsMain");
         SetPanelNavigation("GraphicsOptions", "", "OptionsMain");
         SetPanelNavigation("ControlsOptions", "", "OptionsMain");
         SetPanelNavigation("GameplayOptions", "", "OptionsMain");
         SetPanelNavigation("PauseMenu", "", "HUD");
-        
+        SetPanelNavigation("HUD", "PauseMenu", "");
+        SetPanelNavigation("Loading", "HUD", "");
+
         LogDebug("✅ Navigation configured");
     }
-    
+
     void SetPanelNavigation(string panelID, string nextID, string previousID)
     {
         if (createdPanels.TryGetValue(panelID, out GameObject panelGO))
@@ -652,10 +668,27 @@ public class CompleteUIGenerator : MonoBehaviour
             ConcreteUIPanel panel = panelGO.GetComponent<ConcreteUIPanel>();
             if (panel != null)
             {
-                panel.nextPanelID = nextID ?? "";
-                panel.previousPanelID = previousID ?? "";
+                panel.SetNavigation(nextID ?? "", previousID ?? "");
             }
         }
+    }
+
+    IEnumerator SimulateLoading()
+    {
+        if (loadingFillImage == null)
+            yield break;
+
+        loadingFillImage.fillAmount = 0f;
+        float duration = 2f;
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            elapsed += Time.deltaTime;
+            loadingFillImage.fillAmount = Mathf.Clamp01(elapsed / duration);
+            yield return null;
+        }
+
+        uiManager?.ShowPanel("HUD");
     }
     
     void ConfigureUIManager()

--- a/Assets/Scripts/UI/UIPanel.cs
+++ b/Assets/Scripts/UI/UIPanel.cs
@@ -127,14 +127,25 @@ public abstract class UIPanel : MonoBehaviour
         LogDebug("Show animation completed");
     }
     
-    public virtual void OnHideComplete() 
+    public virtual void OnHideComplete()
     {
         LogDebug("Hide animation completed");
     }
-    
+
     #endregion
 
     #region Navigation
+
+    /// <summary>
+    /// Configura la navegación hacia el siguiente y anterior panel.
+    /// </summary>
+    /// <param name="nextID">ID del siguiente panel.</param>
+    /// <param name="previousID">ID del panel previo.</param>
+    public void SetNavigation(string nextID, string previousID)
+    {
+        nextPanelID = nextID;
+        previousPanelID = previousID;
+    }
     
     public virtual void GoToNextPanel()
     {


### PR DESCRIPTION
## Summary
- add `SetNavigation` helper in `UIPanel`
- generate navigation via `SetNavigation` in `CompleteUIGenerator`
- implement simulated loading bar and functional main menu buttons
- wire up panel navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf1f7472c832aa026dc20779baa51