### PR TITLE
Spawn player at start and show HUD

### DIFF
--- a/Assets/Scripts/Core/Managers/AudioManager.cs
+++ b/Assets/Scripts/Core/Managers/AudioManager.cs
@@ -94,7 +94,8 @@ public class AudioManager : MonoBehaviour
         
         // Cargar configuración guardada
         LoadVolumeSettings();
-        
+        ApplyConfigurationValues();
+
         Debug.Log($"🔊 AudioManager initialized with {sfxPoolSize} SFX sources");
     }
     
@@ -443,6 +444,23 @@ public class AudioManager : MonoBehaviour
     public VolumeSettings GetVolumeSettings()
     {
         return volumeSettings;
+    }
+
+    /// <summary>
+    /// Apply configuration values from the global AudioConfig to this manager.
+    /// </summary>
+    public void ApplyConfigurationValues()
+    {
+        if (ConfigurationManager.Instance == null || ConfigurationManager.Audio == null)
+            return;
+
+        var config = ConfigurationManager.Audio;
+
+        SetMasterVolume(config.masterVolume);
+        SetMusicVolume(config.musicVolume);
+        SetSFXVolume(config.sfxVolume);
+        SetUIVolume(config.uiVolume);
+        SetAmbienceVolume(config.ambienceVolume);
     }
     
     #endregion

--- a/Assets/Scripts/Core/Managers/GameplayInitializer.cs
+++ b/Assets/Scripts/Core/Managers/GameplayInitializer.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+
+/// <summary>
+/// Ensures the HUD is visible and the player spawns at the designated spawn point
+/// when a gameplay scene loads.
+/// </summary>
+public class GameplayInitializer : MonoBehaviour
+{
+    [SerializeField] private bool showHUDOnStart = true;
+
+    void Start()
+    {
+        SpawnPlayerAtPoint();
+        if (showHUDOnStart)
+        {
+            ShowHUD();
+        }
+    }
+
+    void SpawnPlayerAtPoint()
+    {
+        if (GameManager.Instance == null)
+            return;
+
+        var player = GameManager.Instance.player;
+        if (player == null)
+            player = FindObjectOfType<PlayerStateMachine>();
+
+        if (player == null)
+            return;
+
+        Transform spawn = GameManager.Instance.playerSpawnPoint;
+        if (spawn != null)
+        {
+            player.transform.SetPositionAndRotation(spawn.position, spawn.rotation);
+        }
+        else
+        {
+            Debug.LogWarning("[GameplayInitializer] No player spawn point assigned.");
+        }
+    }
+
+    void ShowHUD()
+    {
+        if (UIManager.Instance != null)
+        {
+            UIManager.Instance.ShowPanel("HUD");
+        }
+        else
+        {
+            Debug.LogWarning("[GameplayInitializer] UIManager not found to show HUD.");
+        }
+    }
+}

--- a/Assets/Scripts/Core/Managers/InputManager.cs
+++ b/Assets/Scripts/Core/Managers/InputManager.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using System.Collections.Generic;
 using System.Collections;
-using InputConfig = InputConfig;
 
 public class InputManager : MonoBehaviour
 {
@@ -65,7 +64,8 @@ public class InputManager : MonoBehaviour
         
         Instance = this;
         DontDestroyOnLoad(gameObject);
-        
+
+        ApplyConfigurationValues();
         InitializeInputSystem();
     }
     
@@ -516,6 +516,19 @@ public class InputManager : MonoBehaviour
         {
             Debug.Log($"🎮 Input [{inputName}]: {value}");
         }
+    }
+
+    /// <summary>
+    /// Apply configuration values from the global InputConfig to this manager.
+    /// </summary>
+    public void ApplyConfigurationValues()
+    {
+        if (ConfigurationManager.Instance == null || ConfigurationManager.Input == null)
+            return;
+
+        var config = ConfigurationManager.Input;
+        enableInputBuffering = config.bufferInputs;
+        inputBufferTime = config.inputBufferTime;
     }
     
     void ToggleDebugMode()

--- a/Assets/Scripts/UI/CompleteUIGenerator.cs
+++ b/Assets/Scripts/UI/CompleteUIGenerator.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
 using TMPro;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,6 +31,9 @@ public class CompleteUIGenerator : MonoBehaviour
     [Header("🎮 Game Settings")]
     [SerializeField] private int maxSaveSlots = 3;
     [SerializeField] private bool supportControllerInput = true;
+
+    [Header("🏞️ Scene Settings")]
+    [SerializeField] private string gameplaySceneName = "Lobby";
     
     [Header("📊 Generation Results")]
     [SerializeField] private int panelsCreated = 0;
@@ -74,6 +78,25 @@ public class CompleteUIGenerator : MonoBehaviour
     private string language = "Español";
     private float mouseSensitivity = 0.5f;
     private bool invertY = false;
+
+    void LoadConfigurationValues()
+    {
+        if (ConfigurationManager.Instance == null) return;
+
+        if (ConfigurationManager.Audio != null)
+        {
+            masterVolume = ConfigurationManager.Audio.masterVolume;
+            musicVolume = ConfigurationManager.Audio.musicVolume;
+            sfxVolume = ConfigurationManager.Audio.sfxVolume;
+            voiceVolume = ConfigurationManager.Audio.voiceVolume;
+        }
+
+        if (ConfigurationManager.Input != null)
+        {
+            mouseSensitivity = ConfigurationManager.Input.mouseSensitivity;
+            invertY = ConfigurationManager.Input.invertMouseY;
+        }
+    }
     
     void Start()
     {
@@ -89,6 +112,8 @@ public class CompleteUIGenerator : MonoBehaviour
         uiManager = uiManager ?? FindObjectOfType<UIManager>();
         Debug.Log($"✅ UIManager asignado: {(uiManager != null ? "Sí" : "NO")}");
         LogDebug("🚀 Starting Complete UI Generation...");
+
+        LoadConfigurationValues();
         
         try
         {
@@ -999,10 +1024,10 @@ public class CompleteUIGenerator : MonoBehaviour
         descText.alignment = TextAlignmentOptions.Center;
         
         // Botones de acción
-        CreateButton(panel.transform, "COMENZAR", new Vector2(-100, -250), new Vector2(180, 50), 
+        CreateButton(panel.transform, "COMENZAR", new Vector2(-100, -250), new Vector2(180, 50),
             () => {
                 LogDebug("Iniciando nueva partida...");
-                uiManager?.ShowPanel("HUD");
+                SceneManager.LoadScene(gameplaySceneName);
             });
             
         CreateButton(panel.transform, "VOLVER", new Vector2(100, -250), new Vector2(180, 50), 
@@ -1057,10 +1082,10 @@ public class CompleteUIGenerator : MonoBehaviour
                 
                 // Botones
                 int slotIndex = i;
-                CreateButton(saveContainer.transform, "CARGAR", new Vector2(200, 0), new Vector2(100, 40), 
+                CreateButton(saveContainer.transform, "CARGAR", new Vector2(200, 0), new Vector2(100, 40),
                     () => {
                         LogDebug($"Cargando partida {slotIndex}...");
-                        uiManager?.ShowPanel("HUD");
+                        SceneManager.LoadScene(gameplaySceneName);
                     });
                     
                 CreateButton(saveContainer.transform, "BORRAR", new Vector2(320, 0), new Vector2(80, 30), 
@@ -1356,6 +1381,8 @@ void GenerateVideoOptionsPanel()
         CreateSlider(panel.transform, "Volumen General:", new Vector2(0, 200), new Vector2(300, 20), 0, 1, masterVolume,
             (float value) => {
                 masterVolume = value;
+                if (ConfigurationManager.Instance != null)
+                    ConfigurationManager.Audio.masterVolume = value;
                 LogDebug($"Volumen maestro: {value}");
             });
         
@@ -1363,6 +1390,8 @@ void GenerateVideoOptionsPanel()
         CreateSlider(panel.transform, "Música:", new Vector2(0, 140), new Vector2(300, 20), 0, 1, musicVolume,
             (float value) => {
                 musicVolume = value;
+                if (ConfigurationManager.Instance != null)
+                    ConfigurationManager.Audio.musicVolume = value;
                 LogDebug($"Volumen música: {value}");
             });
         
@@ -1370,6 +1399,8 @@ void GenerateVideoOptionsPanel()
         CreateSlider(panel.transform, "Efectos:", new Vector2(0, 80), new Vector2(300, 20), 0, 1, sfxVolume,
             (float value) => {
                 sfxVolume = value;
+                if (ConfigurationManager.Instance != null)
+                    ConfigurationManager.Audio.sfxVolume = value;
                 LogDebug($"Volumen SFX: {value}");
             });
         
@@ -1377,6 +1408,8 @@ void GenerateVideoOptionsPanel()
         CreateSlider(panel.transform, "Voces:", new Vector2(0, 20), new Vector2(300, 20), 0, 1, voiceVolume,
             (float value) => {
                 voiceVolume = value;
+                if (ConfigurationManager.Instance != null)
+                    ConfigurationManager.Audio.voiceVolume = value;
                 LogDebug($"Volumen voces: {value}");
             });
         
@@ -1414,6 +1447,8 @@ void GenerateVideoOptionsPanel()
         CreateSlider(panel.transform, "Sensibilidad Ratón:", new Vector2(0, 200), new Vector2(300, 20), 0.1f, 2f, mouseSensitivity,
             (float value) => {
                 mouseSensitivity = value;
+                if (ConfigurationManager.Instance != null)
+                    ConfigurationManager.Input.mouseSensitivity = value;
                 LogDebug($"Sensibilidad ratón: {value}");
             });
         
@@ -1421,6 +1456,8 @@ void GenerateVideoOptionsPanel()
         CreateToggle(panel.transform, "Invertir Eje Y", new Vector2(0, 140), invertY,
             (bool value) => {
                 invertY = value;
+                if (ConfigurationManager.Instance != null)
+                    ConfigurationManager.Input.invertMouseY = value;
                 LogDebug($"Invertir Y: {value}");
             });
         

--- a/Assets/Scripts/UI/OptionsMenuPanel.cs
+++ b/Assets/Scripts/UI/OptionsMenuPanel.cs
@@ -493,6 +493,7 @@ public class OptionsMenuPanel : UIPanel
                 config.qualityLevel = QualityLevel.High;
                 config.vSyncEnabled = true;
                 config.fullScreenMode = FullScreenMode.FullScreenWindow;
+                config.ValidateValues();
             }
             
             // Reset input
@@ -501,11 +502,22 @@ public class OptionsMenuPanel : UIPanel
                 var config = ConfigurationManager.Input;
                 config.mouseSensitivity = 2f;
                 config.invertMouseY = false;
+                config.ValidateValues();
             }
             
-            // Reload UI
+            // Apply changes
+            if (UIValidation.ValidateManager(InputManager.Instance, "InputManager"))
+            {
+                InputManager.Instance.ApplyConfigurationValues();
+            }
+
+            if (UIValidation.ValidateManager(AudioManager.Instance, "AudioManager"))
+            {
+                AudioManager.Instance.ApplyConfigurationValues();
+            }
+
             LoadCurrentSettings();
-            
+
             LogDebug("Settings reset to defaults");
         }
         catch (System.Exception e)
@@ -519,13 +531,26 @@ public class OptionsMenuPanel : UIPanel
         try
         {
             LogDebug("Applying settings");
-            
-            // Apply graphics settings
+
+            // Graphics
             if (UIValidation.ValidateManager(ConfigurationManager.Graphics, "GraphicsConfig"))
             {
+                ConfigurationManager.Graphics.ValidateValues();
                 ConfigurationManager.Graphics.ApplySettings();
             }
-            
+
+            // Audio
+            if (UIValidation.ValidateManager(AudioManager.Instance, "AudioManager"))
+            {
+                AudioManager.Instance.ApplyConfigurationValues();
+            }
+
+            // Input
+            if (UIValidation.ValidateManager(InputManager.Instance, "InputManager"))
+            {
+                InputManager.Instance.ApplyConfigurationValues();
+            }
+
             LogDebug("Settings applied successfully");
         }
         catch (System.Exception e)


### PR DESCRIPTION
## Summary
- spawn player at the GameManager spawn point
- ensure HUD panel shows when gameplay scenes load
- apply Audio and Input configuration settings through the options menu
- allow Options reset/apply buttons to update manager settings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c6b17ac80832a8f5295c95811c03a