### PR TITLE
Fix panel inheritance and configuration manager generics

### DIFF
--- a/Assets/Scripts/Core/Managers/AudioManager.cs
+++ b/Assets/Scripts/Core/Managers/AudioManager.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.Audio;
 using System.Collections;
 using System.Collections.Generic;
+using UISystem.Configuration;
 
 public class AudioManager : MonoBehaviour
 {

--- a/Assets/Scripts/Core/Managers/ConfigurationManager.cs
+++ b/Assets/Scripts/Core/Managers/ConfigurationManager.cs
@@ -60,7 +60,7 @@ namespace UISystem.Configuration
             };
         }
 
-        public T GetConfiguration<T>(string key, ConfigurationProviderType? providerType = null) where T : class
+        public T GetConfiguration<T>(string key, ConfigurationProviderType? providerType = null) where T : ScriptableObject
         {
             var provider = providerType ?? defaultProvider;
 
@@ -82,7 +82,7 @@ namespace UISystem.Configuration
         }
 
         public void SaveConfiguration<T>(string key, T data, ConfigurationProviderType? providerType = null)
-            where T : class
+            where T : ScriptableObject
         {
             var provider = providerType ?? defaultProvider;
             providers[provider].SaveConfiguration(key, data);

--- a/Assets/Scripts/UI/ConcreteUIPanel.cs
+++ b/Assets/Scripts/UI/ConcreteUIPanel.cs
@@ -1,28 +1,26 @@
 using UISystem.Core;
+using UISystem.Panels;
 using UnityEngine;
 
 /// <summary>
 /// Implementación concreta de UIPanel para uso con el generador
 /// </summary>
-public class ConcreteUIPanel BaseUIPanel
+public class ConcreteUIPanel : BaseUIPanel
 {
     [Header("🎯 Panel Configuration")]
-    
+    [SerializeField] private string panelID = "";
+    [SerializeField] private bool startVisible = true;
+    [SerializeField] private bool useScaleAnimation = true;
+
     [Header("🔧 Custom Actions")]
     public UnityEngine.Events.UnityEvent onPanelShown;
     public UnityEngine.Events.UnityEvent onPanelHidden;
     
     protected override void OnInitialize()
     {
-        // Configurar propiedades usando reflection para compatibilidad
-        var startVisibleField = typeof(UIPanel).GetField("startVisible", 
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        
-        if (startVisibleField != null)
-        {
-            startVisibleField.SetValue(this, startVisible);
-        }
-        
+        // Apply initial visibility
+        startHidden = !startVisible;
+
         LogDebug($"ConcreteUIPanel '{panelID}' initialized");
     }
     
@@ -119,5 +117,10 @@ public class ConcreteUIPanel BaseUIPanel
         {
             UIManager.Instance.PlayClickSound();
         }
+    }
+
+    void LogDebug(string message)
+    {
+        Debug.Log($"[ConcreteUIPanel] {message}");
     }
 }

--- a/Assets/Scripts/UI/OptionsMenuPanel.cs
+++ b/Assets/Scripts/UI/OptionsMenuPanel.cs
@@ -4,10 +4,16 @@ using TMPro;
 using System.Collections.Generic;
 using UISystem.Configuration;
 using UISystem.Core;
+using UISystem.Panels;
 using UnityEngine.Events;
 
-public class OptionsMenuPanel BaseUIPanel
+public class OptionsMenuPanel : BaseUIPanel
 {
+    [Header("\uD83D\uDCCD Panel Configuration")]
+    [SerializeField] private string panelID = "";
+    [SerializeField] private bool startVisible = true;
+    [SerializeField] private bool useScaleAnimation = true;
+    [SerializeField] private bool blockGameInput = false;
     [Header("🔊 Audio Options")]
     [SerializeField] private Slider masterVolumeSlider;
     [SerializeField] private Slider musicVolumeSlider;
@@ -673,5 +679,15 @@ public class OptionsMenuPanel BaseUIPanel
         if (backButton != null) backButton.onClick.RemoveAllListeners();
         if (resetToDefaultsButton != null) resetToDefaultsButton.onClick.RemoveAllListeners();
         if (applyButton != null) applyButton.onClick.RemoveAllListeners();
+    }
+
+    void LogDebug(string message)
+    {
+        Debug.Log($"[OptionsMenuPanel] {message}");
+    }
+
+    void LogError(string message)
+    {
+        Debug.LogError($"[OptionsMenuPanel] {message}");
     }
 }

--- a/Assets/Scripts/UI/Panels/MainMenuPanel.cs
+++ b/Assets/Scripts/UI/Panels/MainMenuPanel.cs
@@ -1,12 +1,17 @@
 using UISystem.Core;
+using UISystem.Panels;
 using UnityEngine;
 using UnityEngine.UI;
 
 /// <summary>
 /// Panel específico para el menú principal
 /// </summary>
-public class MainMenuUIPanel BaseUIPanel
+public class MainMenuUIPanel : BaseUIPanel
 {
+    [Header("\uD83D\uDCCD Panel Configuration")]
+    [SerializeField] private string panelID = "";
+    [SerializeField] private bool startVisible = true;
+    [SerializeField] private bool useScaleAnimation = true;
     [Header("🎮 Main Menu Buttons")]
     public Button newGameButton;
     public Button loadGameButton;
@@ -53,5 +58,10 @@ public class MainMenuUIPanel BaseUIPanel
 #endif
             });
         }
+    }
+
+    void LogDebug(string message)
+    {
+        Debug.Log($"[MainMenuUIPanel] {message}");
     }
 }

--- a/Assets/Scripts/UI/Panels/OptionsMainUIPanel.cs
+++ b/Assets/Scripts/UI/Panels/OptionsMainUIPanel.cs
@@ -1,12 +1,17 @@
 using UISystem.Core;
+using UISystem.Panels;
 using UnityEngine;
 using UnityEngine.UI;
 
 /// <summary>
 /// Panel principal de opciones
 /// </summary>
-public class OptionsMainUIPanel BaseUIPanel
+public class OptionsMainUIPanel : BaseUIPanel
 {
+    [Header("\uD83D\uDCCD Panel Configuration")]
+    [SerializeField] private string panelID = "";
+    [SerializeField] private bool startVisible = true;
+    [SerializeField] private bool useScaleAnimation = true;
     protected override void OnInitialize()
     {
         panelID = "OptionsMain";
@@ -34,5 +39,10 @@ public class OptionsMainUIPanel BaseUIPanel
             gameplayBtn.onClick.AddListener(() => UIManager.Instance?.ShowPanel("GameplayOptions"));
         if (backBtn != null)
             backBtn.onClick.AddListener(() => UIManager.Instance?.ShowPanel("MainMenu"));
+    }
+
+    void LogDebug(string message)
+    {
+        Debug.Log($"[OptionsMainUIPanel] {message}");
     }
 }

--- a/Assets/Scripts/UI/PauseMenuPanel.cs
+++ b/Assets/Scripts/UI/PauseMenuPanel.cs
@@ -1,10 +1,16 @@
 
 using UISystem.Core;
+using UISystem.Panels;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class PauseMenuPanel BaseUIPanel
+public class PauseMenuPanel : BaseUIPanel
 {
+    [Header("\uD83D\uDCCD Panel Configuration")]
+    [SerializeField] private string panelID = "";
+    [SerializeField] private bool startVisible = true;
+    [SerializeField] private bool useScaleAnimation = true;
+    [SerializeField] private bool blockGameInput = false;
     [Header("🎛️ Buttons")]
     [SerializeField] private Button resumeButton;
     [SerializeField] private Button optionsButton;
@@ -286,5 +292,20 @@ public class PauseMenuPanel BaseUIPanel
     {
         UnsubscribeFromEvents();
         LogDebug("Pause Menu Panel destroyed");
+    }
+
+    void LogDebug(string message)
+    {
+        Debug.Log($"[PauseMenuPanel] {message}");
+    }
+
+    void LogError(string message)
+    {
+        Debug.LogError($"[PauseMenuPanel] {message}");
+    }
+
+    void LogWarning(string message)
+    {
+        Debug.LogWarning($"[PauseMenuPanel] {message}");
     }
 }


### PR DESCRIPTION
## Summary
- fix namespaces and inheritance for UI panel scripts
- add basic debug logging methods
- adjust ConfigurationManager generic constraints
- include ConfigurationManager namespace in AudioManager

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ccf645050832a9670456809152381